### PR TITLE
Add .gitignore for Arduino artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Ignore Arduino build artifacts
+*.elf
+*.hex
+*.bin
+
+# Ignore build directories
+build/
+
+# Ignore log files
+*.log


### PR DESCRIPTION
## Summary
- create `.gitignore` in repo root
- ignore Arduino build outputs such as `*.elf`, `*.hex`, `*.bin`
- ignore temporary build directories and log files

## Testing
- `git ls-files --others --exclude-standard`


------
https://chatgpt.com/codex/tasks/task_e_6842a795d5b08327886871c365970423